### PR TITLE
Add script for building a version compatible with Ubuntu 14.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+src/
+resources/
+bin/
+.cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# This Dockerfile enables us to build a version that uses libc 2.19,
+# which is what we have on our Ubuntu 14.04 instances.
+FROM ubuntu:trusty
+
+RUN apt-get update && \
+    apt-get install -yy curl
+
+RUN curl -LO https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
+
+RUN tar -xzv -C /usr/local/ -f go1.14.4.linux-amd64.tar.gz
+
+ENV PATH "$PATH:/usr/local/go/bin"
+
+RUN mkdir -p /go
+ENV GOPATH "/go"
+
+RUN apt-get install -yy git-core
+RUN apt-get install -yy build-essential

--- a/build-for-linux.sh
+++ b/build-for-linux.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -o errexit
+
+
+docker build -t full-check-builder .
+docker run -ti --rm -v `pwd`:`pwd` -w `pwd` full-check-builder ./build.sh


### PR DESCRIPTION
This allows us to run it locally on some older servers.  Since this tool uses CGO and libc, it needs to be built with the right version of `libc`, which on Ubuntu 14.04 is `2.19`.